### PR TITLE
Modify recommended npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To make this easier, add scripts to your `package.json` for easy recording/runni
     "test:record": "NOCK_BACK_MODE=record npm test",
     "test:wild": "NOCK_BACK_MODE=wild npm test",
     "test:lockdown": "NOCK_BACK_MODE=lockdown npm test",
-    "test:overwrite": "rm test/fixtures/*.json && npm run test:record"
+    "test:overwrite": "rm test/fixtures/*.json & npm run test:record"
   }
 }
 ```


### PR DESCRIPTION
By using `&` instead of `&&` in the script, the script will not fail if there are no fixtures to delete. It will show a warning and continue instead.
