### PR TITLE
Fix TypeScript definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Jetbrains WebStorm
+.idea
+
 # Logs
 logs
 *.log

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,20 +1,7 @@
-import nock = require('nock')
 import tape = require('tape')
+import tapeNock = require('./modified_tape')
 
 export = tapeNockFactory
-
-declare function tapeNock (name: string, cb: tape.TestCase): void
-declare function tapeNock (name: string, opts: tape.TestOptions, cb: tape.TestCase): void
-declare function tapeNock (cb: tape.TestCase): void
-declare function tapeNock (opts: tape.TestOptions, cb: tape.TestCase): void
-declare namespace tapeNock {
-  export let nock: typeof nock & {
-    cleanAll: typeof nock.cleanAll
-    disableNetConnect: typeof nock.disableNetConnect
-    enableNetConnect: typeof nock.enableNetConnect
-    recorder: nock.Recorder
-  }
-}
 
 declare function tapeNockFactory (tapeTest: typeof tape, nockOpts: { fixtures: string, mode?: string }): typeof tapeNock
 declare namespace tapeNockFactory {}

--- a/modified_tape.d.ts
+++ b/modified_tape.d.ts
@@ -1,0 +1,92 @@
+import nock2 = require('nock')
+
+export = tape
+
+declare function tape(name: string, cb: tape.TestCase): void;
+declare function tape(name: string, opts: tape.TestOptions, cb: tape.TestCase): void;
+declare function tape(cb: tape.TestCase): void;
+declare function tape(opts: tape.TestOptions, cb: tape.TestCase): void;
+
+declare namespace tape {
+  interface TestCase {
+    (test: Test): void;
+  }
+
+  interface TestOptions {
+    skip?: boolean;
+    timeout?: number;
+  }
+
+  interface StreamOptions {
+    objectMode?: boolean;
+  }
+
+  export function skip(name: string, cb: tape.TestCase): void;
+  export function only(name: string, cb: tape.TestCase): void;
+  export function createHarness(): typeof tape;
+  export function createStream(opts?: tape.StreamOptions): NodeJS.ReadableStream;
+
+  interface Test {
+    test(name: string, cb: tape.TestCase): void;
+    plan(n: number): void;
+    end(err?: any): void;
+    fail(msg?: string): void;
+    pass(msg?: string): void;
+    timeoutAfter(ms: number): void;
+    skip(msg?: string): void;
+    ok(value: any, msg?: string): void;
+    true(value: any, msg?: string): void;
+    assert(value: any, msg?: string): void;
+    notOk(value: any, msg?: string): void;
+    false(value: any, msg?: string): void;
+    notok(value: any, msg?: string): void;
+    error(err: any, msg?: string): void;
+    ifError(err: any, msg?: string): void;
+    ifErr(err: any, msg?: string): void;
+    iferror(err: any, msg?: string): void;
+    equal(a: any, b: any, msg?: string): void;
+    equals(a: any, b: any, msg?: string): void;
+    isEqual(a: any, b: any, msg?: string): void;
+    is(a: any, b: any, msg?: string): void;
+    strictEqual(a: any, b: any, msg?: string): void;
+    strictEquals(a: any, b: any, msg?: string): void;
+    notEqual(a: any, b: any, msg?: string): void;
+    notEquals(a: any, b: any, msg?: string): void;
+    notStrictEqual(a: any, b: any, msg?: string): void;
+    notStrictEquals(a: any, b: any, msg?: string): void;
+    isNotEqual(a: any, b: any, msg?: string): void;
+    isNot(a: any, b: any, msg?: string): void;
+    not(a: any, b: any, msg?: string): void;
+    doesNotEqual(a: any, b: any, msg?: string): void;
+    isInequal(a: any, b: any, msg?: string): void;
+    deepEqual(a: any, b: any, msg?: string): void;
+    deepEquals(a: any, b: any, msg?: string): void;
+    isEquivalent(a: any, b: any, msg?: string): void;
+    same(a: any, b: any, msg?: string): void;
+    notDeepEqual(a: any, b: any, msg?: string): void;
+    notEquivalent(a: any, b: any, msg?: string): void;
+    notDeeply(a: any, b: any, msg?: string): void;
+    notSame(a: any, b: any, msg?: string): void;
+    isNotDeepEqual(a: any, b: any, msg?: string): void;
+    isNotDeeply(a: any, b: any, msg?: string): void;
+    isNotEquivalent(a: any, b: any, msg?: string): void;
+    isInequivalent(a: any, b: any, msg?: string): void;
+    deepLooseEqual(a: any, b: any, msg?: string): void;
+    looseEqual(a: any, b: any, msg?: string): void;
+    looseEquals(a: any, b: any, msg?: string): void;
+    notDeepLooseEqual(a: any, b: any, msg?: string): void;
+    notLooseEqual(a: any, b: any, msg?: string): void;
+    notLooseEquals(a: any, b: any, msg?: string): void;
+    throws(fn: () => void, msg?: string): void;
+    throws(fn: () => void, exceptionExpected: RegExp | (() => void), msg?: string): void;
+    doesNotThrow(fn: () => void, msg?: string): void;
+    doesNotThrow(fn: () => void, exceptionExpected: RegExp | (() => void), msg?: string): void;
+    comment(msg: string): void;
+  }
+}
+
+// MODIFICATION
+
+declare namespace tape {
+  export import nock = nock2
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tape-nock",
   "description": "Automatically record and playback HTTP calls for each tape test.",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Dan Flettre <fletd01@yahoo.com>",
   "bugs": {
     "url": "https://github.com/Flet/tape-nock/issues"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tape-nock",
   "description": "Automatically record and playback HTTP calls for each tape test.",
-  "version": "1.2.3",
+  "version": "1.2.2",
   "author": "Dan Flettre <fletd01@yahoo.com>",
   "bugs": {
     "url": "https://github.com/Flet/tape-nock/issues"


### PR DESCRIPTION
Recently I noticed, that tape methods (skip, only) not typed.
Because TypeScript can't extend external namespace, I copy&paste tape typing and added nock property

Also, do we really need nock on tape as property, can't we just export it from tape-nock?
