### PR TITLE
bumps nock version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@types/nock": "^0.54.30",
     "@types/tape": "^4.2.27",
-    "nock": "^7.0.2",
+    "nock": "^9.0.9",
     "sanitize-filename": "^1.5.3"
   },
   "typings": "index.d.ts"


### PR DESCRIPTION
Bumps nock version to 9.0.9. No unit tests have been broken by this bump.