### PR TITLE
new feature: defaultTestOptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build/Release
 node_modules
 .history
 .vs_code
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,18 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## next
+* New feature: `defaultTestOptons` - set *before*, *after*, and *afterRecord* functions for all tests when `tapeNock` is defined.
+* Added example of using `tape-nock` with `supertest` to the README.
+* expose `nock` via `tapeNock.nock`
+
 ## 1.5.2 2017-04-01 (latest)
 * reduces dev scripts boilerplate
 
 ## 1.5.1 2017-04-01
 * adds coveralls
 
-# 1.5.0 2017-03-31 Uses default nockOptions with fixtures set to sibiling folder to test script 
+# 1.5.0 2017-03-31 Uses default nockOptions with fixtures set to sibiling folder to test script
 * we can use it now with ```var test = require('tape-nock')(tape)```
 
 ## 1.4.1 2017-03-23

--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ function tapeNockFactory (tapeTest, nockOpts) {
   nockBack.fixtures = nockOpts.fixtures || path.join(path.dirname(module.parent.filename), 'fixtures')
   if (nockOpts.mode) nockBack.setMode(nockOpts.mode)
 
+  var defaultTestOptions = nockOpts.defaultTestOptions || {}
+
   var testnames = []
 
   function testTestWithNock (fn) {
@@ -29,7 +31,7 @@ function tapeNockFactory (tapeTest, nockOpts) {
 
       var emitter = fn(args.name, args.opts, args.cb)
       emitter.once('prerun', function () {
-        nockBack(filename, args.opts, function (nockDone) {
+        nockBack(filename, Object.assign({}, defaultTestOptions, args.opts), function (nockDone) {
           emitter.once('end', function () {
             nockDone()
           })
@@ -52,6 +54,8 @@ function tapeNockFactory (tapeTest, nockOpts) {
 
   return testWithNock
 }
+
+tapeNockFactory.nock = nock
 
 var getTestArgs = function (name_, opts_, cb_) {
   var name = '(anonymous)'

--- a/test/default-test-options.js
+++ b/test/default-test-options.js
@@ -1,0 +1,23 @@
+var tape = require('tape')
+var beforeWorks = false
+
+var test = require('../')(tape, {
+  defaultTestOptions: {
+    before: function () {
+      beforeWorks = true
+    }
+  }
+})
+
+var request = require('request')
+
+test('hello world', function (t) {
+  request.get('http://registry.npmjs.org', process)
+
+  function process (err, resp) {
+    t.error(err, 'no error')
+    t.ok(resp)
+    t.ok(beforeWorks, 'default test option works')
+    t.end()
+  }
+})


### PR DESCRIPTION
* New feature: `defaultTestOptons` - set *before*, *after*, and *afterRecord* functions for all tests when `tapeNock` is defined.
* Added example of using `tape-nock` with `supertest` to the README.
* expose `nock` via `tapeNock.nock`

looking for a quick review! :)